### PR TITLE
fix archive type of plugin files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test: deps
 
 dist: deps
 	@echo "===> Shipping packages as release assets..."
-	goxz -d $(ASSETS_DIR) -os $(XC_OS) -arch $(XC_ARCH)
+	goxz -d $(ASSETS_DIR) -z -os $(XC_OS) -arch $(XC_ARCH)
 
 release:
 	@echo "===> Publishing release assets to GitHub..."


### PR DESCRIPTION
related to install of this plugin.

```shell
ubuntu@sample:~$ sudo mkr plugin install --upgrade mackerel-plugin-jitsi-videobridge@v0.0.1
           Downloading https://github.com/tomohiro/mackerel-plugin-jitsi-videobridge/releases/download/v0.0.1/mackerel-plugin-jitsi-videobridge_linux_amd64.zip
error Failed to install plugin while downloading an artifact: http response not OK. code: 404, url: https://github.com/tomohiro/mackerel-plugin-jitsi-videobridge/releases/download/v0.0.1/mackerel-plugin-jitsi-videobridge_linux_amd64.zip
```

Since "mkr plugin install" expects a zip archived file type, it seems to have to specify "-z" in goxz used to archive the plugin.

[mackerelio, doc, make plugin corresponding to installer](https://mackerel.io/ja/docs/entry/advanced/make-plugin-corresponding-to-installer)